### PR TITLE
Improved clarity of expiry date calculation

### DIFF
--- a/AwesomeCache/CacheObject.swift
+++ b/AwesomeCache/CacheObject.swift
@@ -33,12 +33,9 @@ class CacheObject : NSObject, NSCoding {
      *  Returns true if this object is expired.
 	 *  Expiry of the object is determined by its expiryDate.
      */
-	func isExpired() -> Bool {
-		let expires = expiryDate.timeIntervalSinceNow
-		let now = NSDate().timeIntervalSinceNow
-		
-		return now > expires
-	}
+    func isExpired() -> Bool {
+        return expiryDate.isInThePast
+    }
 	
 	
 	/// NSCoding
@@ -54,4 +51,10 @@ class CacheObject : NSObject, NSCoding {
 		aCoder.encodeObject(value, forKey: "value")
 		aCoder.encodeObject(expiryDate, forKey: "expiryDate")
 	}
+}
+
+extension NSDate {
+    var isInThePast: Bool {
+        return self.timeIntervalSinceNow < 0
+    }
 }

--- a/AwesomeCache/CacheObject.swift
+++ b/AwesomeCache/CacheObject.swift
@@ -18,20 +18,21 @@ class CacheObject : NSObject, NSCoding {
 	let value: AnyObject
 	let expiryDate: NSDate
 	
-	/**
-	 *  Designated initializer. 
-	 *
-     *  @param value			An object that should be cached
-	 *  @param expiryDate	The expiry date of the given value
+    /**
+     * Designated initializer.
+     *
+     * :param: value      An object that should be cached
+     * :param: expiryDate The expiry date of the given value
      */
 	init(value: AnyObject, expiryDate: NSDate) {
 		self.value = value
 		self.expiryDate = expiryDate
 	}
 	
-	/**
-     *  Returns true if this object is expired.
-	 *  Expiry of the object is determined by its expiryDate.
+    /**
+     * Determines if cached object is expired
+     *
+     * :returns: True If objects expiry date has passed
      */
     func isExpired() -> Bool {
         return expiryDate.isInThePast


### PR DESCRIPTION
Changed to use a computed property on NSDate. This way date calculation are handled by the appropriate class. Also we do not have to use `NSDate().timeIntervalSinceNow`.

Also changed Documentation to use new reStructuredText format.