### PR TITLE
Adds completion callback to removeAllObjects

### DIFF
--- a/AwesomeCache/Cache.swift
+++ b/AwesomeCache/Cache.swift
@@ -200,8 +200,10 @@ public class Cache<T: NSCoding> {
 	
 	/**
 	 *  Removes all objects from the cache.
+	 *
+	 *  @param completion	Called as soon as all cached objects are removed from disk.
 	 */
-	public func removeAllObjects() {
+	public func removeAllObjects(completion: (() -> Void)? = nil) {
 		cache.removeAllObjects()
 		
 		dispatch_async(diskWriteQueue) {
@@ -211,6 +213,10 @@ public class Cache<T: NSCoding> {
 			for key in keys {
 				let path = self.pathForKey(key)
 				self.fileManager.removeItemAtPath(path, error: nil)
+			}
+
+			dispatch_async(dispatch_get_main_queue()) {
+				completion?()
 			}
 		}
 	}

--- a/AwesomeCache/Cache.swift
+++ b/AwesomeCache/Cache.swift
@@ -259,15 +259,15 @@ public class Cache<T: NSCoding> {
 	// MARK: Private Helper
 	
 	private func pathForKey(key: String) -> String {
-        let k = sanitizedKey(key)
+		let k = sanitizedKey(key)
 		return cacheDirectory.stringByAppendingPathComponent(k).stringByAppendingPathExtension("cache")!
 	}
-    
-    private func sanitizedKey(key: String) -> String {
-        let regex = NSRegularExpression(pattern: "[^a-zA-Z0-9_]+", options: NSRegularExpressionOptions(), error: nil)!
-        let range = NSRange(location: 0, length: count(key))
-        return regex.stringByReplacingMatchesInString(key, options: NSMatchingOptions(), range: range, withTemplate: "-")
-    }
+	
+	private func sanitizedKey(key: String) -> String {
+		let regex = NSRegularExpression(pattern: "[^a-zA-Z0-9_]+", options: NSRegularExpressionOptions(), error: nil)!
+		let range = NSRange(location: 0, length: count(key))
+		return regex.stringByReplacingMatchesInString(key, options: NSMatchingOptions(), range: range, withTemplate: "-")
+	}
 
 	private func expiryDateForCacheExpiry(expiry: CacheExpiry) -> NSDate {
 		switch expiry {

--- a/AwesomeCacheTests/AwesomeCacheTests.swift
+++ b/AwesomeCacheTests/AwesomeCacheTests.swift
@@ -44,6 +44,27 @@ class AwesomeCacheTests: XCTestCase {
         cache.removeObjectForKey("remove")
         XCTAssertNil(cache.objectForKey("remove"), "Get deleted object")
     }
+
+    func testRemoveAllObjects() {
+        cache.setObject("AddedString 1", forKey: "remove 1")
+        cache.setObject("AddedString 2", forKey: "remove 2")
+        XCTAssertNotNil(cache.objectForKey("remove 1"), "Get first non-nil object")
+        XCTAssertNotNil(cache.objectForKey("remove 2"), "Get second non-nil object")
+
+        let expectation = expectationWithDescription("Remove All Objects")
+
+        cache.removeAllObjects {
+            XCTAssertNil(self.cache.objectForKey("remove 1"), "Get first deleted object")
+            XCTAssertNil(self.cache.objectForKey("remove 2"), "Get second deleted object")
+            expectation.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(4) { error in
+            if let error = error {
+                print("\n\n\nError: \(error.localizedDescription)\n\n\n")
+            }
+        }
+    }
     
     func testSubscripting() {
         cache["addSubscript"] = "AddedString"


### PR DESCRIPTION
We use AwesomeCache in our project, and we want to reliably test removal of objects from our cache. To do this, we have to wait for the files to be removed from disk. There was no way to do this without having a callback in the removeAllObjects method, so we added one.