### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ github "aschuch/AwesomeCache", ~> 2.0
 
 Then run `carthage update`.
 
-#### Cocoapods
+#### CocoaPods
 
 Add the following line to your Podfile.
 
@@ -82,7 +82,7 @@ Add the following line to your Podfile.
 pod "AwesomeCache", "~> 2.0"
 ```
 
-Then run `pod install` with Cocoapods 0.36 or newer.
+Then run `pod install` with CocoaPods 0.36 or newer.
 
 #### Manually
 


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
