### PR TITLE
Remove a comma from carthage setting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The completion block is invoked as soon as the cacheBlock is finished and the ob
 Add the following line to your [Cartfile](https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#cartfile).
 
 ```
-github "aschuch/AwesomeCache", ~> 2.0
+github "aschuch/AwesomeCache" ~> 2.0
 ```
 
 Then run `carthage update`.


### PR DESCRIPTION
Removed ',' from the line of carthage setting in README.md
