### PR TITLE
Add watchos deployment target to podspec

### DIFF
--- a/AwesomeCache.podspec
+++ b/AwesomeCache.podspec
@@ -9,6 +9,7 @@ Pod::Spec.new do |s|
   s.social_media_url      = "http://twitter.com/schuchalexander"
   s.ios.deployment_target = "8.0"
   s.tvos.deployment_target= "9.0"
+  s.watchos.deployment_target= "2.0"
   s.source                = { :git => "https://github.com/aschuch/AwesomeCache.git", :tag => s.version }
   s.requires_arc          = true
   s.source_files          = "AwesomeCache/Cache.swift", "AwesomeCache/CacheObject.swift"


### PR DESCRIPTION
Add the watchOS deployment target to AwesomeCache.podspec so it can be used in a watchOS app.