### PR TITLE
Little fix about file protection

### DIFF
--- a/AwesomeCache/Cache.swift
+++ b/AwesomeCache/Cache.swift
@@ -49,13 +49,14 @@ public class Cache<T: NSCoding> {
             cacheDirectory = url.URLByAppendingPathComponent("com.aschuch.cache/\(name)")
         }
 
+        try fileManager.createDirectoryAtURL(cacheDirectory, withIntermediateDirectories: true, attributes: nil)
+
         // Create directory on disk if needed
         if let fileProtection = fileProtection {
             // Set the correct NSFileProtectionKey
             let protection = [NSFileProtectionKey: fileProtection]
             try fileManager.setAttributes(protection, ofItemAtPath: cacheDirectory.path!)
         }
-        try fileManager.createDirectoryAtURL(cacheDirectory, withIntermediateDirectories: true, attributes: nil)
     }
 
     /// Convenience Initializer

--- a/AwesomeCache/Cache.swift
+++ b/AwesomeCache/Cache.swift
@@ -49,9 +49,9 @@ public class Cache<T: NSCoding> {
             cacheDirectory = url.URLByAppendingPathComponent("com.aschuch.cache/\(name)")
         }
 
+        // Create directory on disk if needed
         try fileManager.createDirectoryAtURL(cacheDirectory, withIntermediateDirectories: true, attributes: nil)
 
-        // Create directory on disk if needed
         if let fileProtection = fileProtection {
             // Set the correct NSFileProtectionKey
             let protection = [NSFileProtectionKey: fileProtection]


### PR DESCRIPTION
If file protection was specified and the directory did not exist yet, it setAttributes would wail. This should fix it