### PR TITLE
Added @escaping to setObject method

### DIFF
--- a/AwesomeCache/Cache.swift
+++ b/AwesomeCache/Cache.swift
@@ -85,7 +85,7 @@ open class Cache<T: NSCoding> {
     ///                         The supplied success or failure blocks must be called upon completion.
     ///                         If the error block is called, the object is not cached and the completion block is invoked with this error.
     /// - parameter completion: Called as soon as a cached object is available to use. The second parameter is true if the object was already cached.
-    open func setObject(forKey key: String, cacheBlock: (CacheBlockClosure, ErrorClosure) -> Void, completion: @escaping (T?, Bool, NSError?) -> Void) {
+    open func setObject(forKey key: String, cacheBlock: (@escaping CacheBlockClosure, @escaping ErrorClosure) -> Void, completion: @escaping (T?, Bool, NSError?) -> Void) {
         if let object = object(forKey: key) {
             completion(object, true, nil)
         } else {


### PR DESCRIPTION
CacheBlockClosure and ErrorClosure are escaping closures, so they need explicit declaration of `@escaping` in Swift 3.
