### PR TITLE
add isOnMemory (recreated)

### DIFF
--- a/AwesomeCache/Cache.swift
+++ b/AwesomeCache/Cache.swift
@@ -141,6 +141,10 @@ open class Cache<T: NSCoding> {
         return objects
     }
 
+    open func isOnMemory(forKey key: String) -> Bool {
+        return cache.object(forKey: key as NSString) != nil
+    }
+
 
     // MARK: Set object
 


### PR DESCRIPTION
Add a way to check whether a cache is on memory for a specific key.
I wanna do things likes below.
1. Check whether a cache is on memory for a specific key.
2. If it is on memory, do 'object(forKey:)' synchronously, because it is guaranteed that object will be returned instantly. 
3. If not on memory, create a thread and operate 'object(forKey:)' asynchronously. it is because 'object(forKey:)' has to access a disk and takes longer time to return the value than when the cache is on memory.

Because of my application have to access hundreds of object, I need to decrease the number of threads as much as I can.

original PR is here https://github.com/aschuch/AwesomeCache/pull/80
