### PR TITLE
Add method to clear internal memory cache

### DIFF
--- a/AwesomeCache/Cache.swift
+++ b/AwesomeCache/Cache.swift
@@ -201,6 +201,11 @@ open class Cache<T: NSCoding> {
         }) 
     }
 
+    /// Removes all objects from memory (and keep them in disk cache).
+    open func removeAllObjectsFromMemory() {
+        cache.removeAllObjects()
+    }
+
     // MARK: Subscripting
 
     open subscript(key: String) -> T? {

--- a/AwesomeCacheTests/AwesomeCacheTests.swift
+++ b/AwesomeCacheTests/AwesomeCacheTests.swift
@@ -64,6 +64,22 @@ class AwesomeCacheTests: XCTestCase {
         XCTAssertNil(cache.object(forKey: "remove 2"), "Removed object should be nil")
     }
 
+    func testRemoveAllObjectsFromMemory() {
+        let cache = try! Cache<NSString>(name: "testRemoveAllObjectsFromMemory")
+
+        cache.setObject("AddedString 1", forKey: "remove only from memory 1")
+        cache.setObject("AddedString 2", forKey: "remove only from memory 2")
+        XCTAssertNotNil(cache.object(forKey: "remove only from memory 1"), "Added object should not be nil")
+        XCTAssertNotNil(cache.object(forKey: "remove only from memory 2"), "Added object should not be nil")
+
+        cache.removeAllObjectsFromMemory()
+        XCTAssertNotNil(cache.object(forKey: "remove only from memory 1"), "Removed object should not be nil")
+        XCTAssertNotNil(cache.object(forKey: "remove only from memory 2"), "Removed object should not be nil")
+
+        XCTAssertNil(cache.cache.object(forKey: "remove only from memory 1"), "Removed object should be nil in NSCache")
+        XCTAssertNil(cache.cache.object(forKey: "remove only from memory 2"), "Removed object should be nil in NSCache")
+    }
+
     func testRemoveExpiredObjects() {
         let cache = try! Cache<NSString>(name: "testRemoveExpiredObjects")
 


### PR DESCRIPTION
Hi,
we are using your AwesomeCache framework in an iOS app with lots of images loaded from network. When a user uses the app for the first time his memory get's flooded with all the images which are persisted in your internal NSCache. This is good for performance, but we need a way to free the cache inside didReceiveMemoryWarning.