### PR TITLE
Retain cache hits in memory when loaded from disk

### DIFF
--- a/AwesomeCache/Cache.swift
+++ b/AwesomeCache/Cache.swift
@@ -235,11 +235,15 @@ open class Cache<T: NSCoding> {
 
         // Otherwise, read from disk
         let path = urlForKey(key).path
-        if fileManager.fileExists(atPath: path) {
-            return _awesomeCache_unarchiveObjectSafely(path) as? CacheObject
+        guard
+            fileManager.fileExists(atPath: path),
+            let object = _awesomeCache_unarchiveObjectSafely(path) as? CacheObject  else {
+            return nil
         }
-
-        return nil
+        
+        // Keep in memory:
+        cache.setObject(object, forKey: key as NSString)
+        return object
     }
 
     // Deletes an object from disk

--- a/AwesomeCacheTests/AwesomeCacheTests.swift
+++ b/AwesomeCacheTests/AwesomeCacheTests.swift
@@ -30,6 +30,21 @@ class AwesomeCacheTests: XCTestCase {
         XCTAssertNotNil(cache.object(forKey: "add"), "Added object should not be nil")
         XCTAssertEqual("AddedString", cache.object(forKey: "add")!, "Fetched object should be equal to the inserted object")
     }
+    
+    func testObjectIsRetainedInMemoryWhenLoadedFromDisk() {
+        let cache = try! Cache<NSString>(name: "testObjectMemoryRetention")
+        
+        //Add to cache, both in-memory and on-disk:
+        cache.setObject("AddedString", forKey: "add")
+        
+        //purge in-memory cache
+        cache.cache.removeAllObjects()
+        
+        //load from disk
+        _ = cache.object(forKey: "add")
+        
+        XCTAssertTrue(cache.isOnMemory(forKey: "add"), "Cached object should be loaded from disk and retained in memory")
+    }
 
     func testGetExpiredObjectIfPresent() {
         let cache = try! Cache<NSString>(name: "testGetExpiredObject")


### PR DESCRIPTION
Currently, if the in-memory cache is purged and on-disk cached items remain, when an item is requested from the cache, it is loaded from disk each time it's requested. This is a fix that simply places items back into the in-memory cache when they're loaded from disk. 

A test has been added. 

Open to other suggestions. 